### PR TITLE
export option for the default region

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This script provides the following commands:
     *   Usage: `aws-sso-helper sso-login [options]`
     *   Options:
         *   `--profile <profile_name>`:  Specify the AWS SSO profile to use for login and credential export. If not provided, it will use the default SSO profile configured in your AWS CLI.
-        *   `--export-as-default`: Exports the session credentials into the `[default]` profile section of your `~/.aws/credentials` file, instead of the section named after the SSO profile, it should be usedd in combo with `--profile <profile_name>`.
+        *   `--export-as-default`: Exports the session credentials into the `[default]` profile section of your `~/.aws/credentials` file, instead of the section named after the SSO profile. This should be used in combination with `--profile <profile_name>`.
+        *   `--export-with-region <region>`: Exports the credentials along with the specified AWS region, adding a `region = <region>` line to the profile. Ex: ` --export-with-region us-east-1`. This is useful if you want to set a default region for the SSO profile in your credentials file.
 
 *   **`export-session-credentials`**:
 
@@ -39,7 +40,9 @@ This script provides the following commands:
     *   Usage: `aws-sso-helper export-session-credentials [options]`
     *   Options:
         *   `--profile <profile_name>`:  Specify the AWS SSO profile to export credentials from. If not provided, it will attempt to use the default SSO profile.
-        *   `--export-as-default`: Exports the session credentials into the `[default]` profile section of your `~/.aws/credentials` file it should be usedd in combo with `--profile <profile_name>`.
+        *   `--export-as-default`: Exports the session credentials into the `[default]` profile section of your `~/.aws/credentials` file. This should be used in combination with `--profile <profile_name>`.
+        *   `--export-with-region <region>`: Exports the credentials along with the specified AWS region. For more details see the `sso-login` command.
+
 
 *   **`sso-logout`**:
 

--- a/aws-sso-helper.sh
+++ b/aws-sso-helper.sh
@@ -18,11 +18,13 @@ print_help() {
   echo ""
   echo "Options for sso-login, export-credentials, sso-logout, and clean-credentials:"
   echo "  --profile <profile_name>  Specify the AWS SSO profile to be used for retrieving the session access or for the logout."
-  echo "  --export-as-default     Export 'aws_access_key_id', 'aws_secret_access_key', 'aws_session_token' in the  ~/.aws/credentials inside the 'default' profile section instead of the one specified by the --profile option."
+  echo "  --export-as-default       Export 'aws_access_key_id', 'aws_secret_access_key', 'aws_session_token' in the  ~/.aws/credentials inside the 'default' profile section instead of the one specified by the --profile option."
+  echo "  --export-with-region <region>  Export the credentials with the specified region."
 }
 
 AWS_SSO_PROFILE=""
 EXPORT_AS_DEFAULT=false # Flag to track --export-as-default
+EXPORT_REGION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +36,10 @@ while [[ $# -gt 0 ]]; do
       EXPORT_AS_DEFAULT=true
       shift 1
       ;;
+    --export-with-region)
+      EXPORT_REGION="$2"
+      shift 2
+      ;;
     *)
       break  # Stop processing options if not recognized
       ;;
@@ -44,6 +50,7 @@ done
 prepare_export_clean_credentials_options() {
   local profile_option=""
   local export_as_default_flag=""
+  local export_with_region_flag=""
 
   if [[ -n "$AWS_SSO_PROFILE" ]]; then
     profile_option=" --profile $AWS_SSO_PROFILE"
@@ -51,7 +58,10 @@ prepare_export_clean_credentials_options() {
   if [[ "$EXPORT_AS_DEFAULT" == "true" ]]; then
     export_as_default_flag=" --export-as-default"
   fi
-  echo "$profile_option $export_as_default_flag"
+  if [[ -n "$EXPORT_REGION" ]]; then
+    export_with_region_flag=" --export-with-region $EXPORT_REGION"
+  fi
+  echo "$profile_option $export_as_default_flag $export_with_region_flag"
 }
 
 # Function to prepare options for aws sso login
@@ -148,5 +158,6 @@ esac
 unset COMMAND
 unset AWS_SSO_PROFILE
 unset EXPORT_AS_DEFAULT
+unset EXPORT_REGION
 
 exit 0

--- a/commands/export_profile_session_into_credentials.sh
+++ b/commands/export_profile_session_into_credentials.sh
@@ -4,6 +4,7 @@ AWS_SSO_PROFILE=""
 AWS_SSO_PROFILE_X_COMMAND=""
 PROFILE_SECTION_NAME="" # Initialize PROFILE_SECTION_NAME
 EXPORT_AS_DEFAULT=false # Flag to track --export-as-default
+EXPORT_REGION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -15,6 +16,10 @@ while [[ $# -gt 0 ]]; do
     --export-as-default)
       EXPORT_AS_DEFAULT=true
       shift 1
+      ;;
+    --export-with-region)
+      EXPORT_REGION="$2"
+      shift 2
       ;;
     *)
       break  # Stop processing options if not recognized
@@ -66,6 +71,9 @@ echo "[$PROFILE_SECTION_NAME]" >> "$CREDENTIALS_FILE"
 echo "aws_access_key_id=$ACCESS_KEY_ID" >> "$CREDENTIALS_FILE"
 echo "aws_secret_access_key=$SECRET_ACCESS_KEY" >> "$CREDENTIALS_FILE"
 echo "aws_session_token=$SESSION_TOKEN" >> "$CREDENTIALS_FILE"
+if [[ -n "$EXPORT_REGION" ]]; then
+  echo "region=$EXPORT_REGION" >> "$CREDENTIALS_FILE"
+fi
 
 echo ""
 echo "$CREDENTIALS_FILE updated."
@@ -76,6 +84,7 @@ unset AWS_SSO_PROFILE
 unset AWS_SSO_PROFILE_X_COMMAND
 unset PROFILE_SECTION_NAME
 unset EXPORT_AS_DEFAULT
+unset EXPORT_REGION
 unset CREDENTIALS_OUTPUT
 unset ACCESS_KEY_ID
 unset SECRET_ACCESS_KEY


### PR DESCRIPTION
Credentials can be exported with a default region via a dedicated option `--export-with-region <region>` in the commands